### PR TITLE
 [DRAFT] Add path parameter to customized plugins

### DIFF
--- a/annotation_template.yaml
+++ b/annotation_template.yaml
@@ -59,6 +59,7 @@ annotation: # Columns to parse
   - type: 'plugin'
     plugin: string # Plugin to apply, could be internal, located into 'plugin' folder, or customized by the user
     field: string
+    path: string # Specify where openvar needs to find plugin; not required 
 
 exclude: # List of field and value that allows to filter out all the rows that have specific value; optional
   - field: string # Field to apply the exclusion

--- a/openvariant/annotation/builder.py
+++ b/openvariant/annotation/builder.py
@@ -249,9 +249,9 @@ def _plugin_builder(x: dict, base_path: str = None) -> PluginBuilder:
         ctxt = _get_plugin_context(mod)
     except ModuleNotFoundError:
         try:
-            files = list(glob.iglob(f"{os.getcwd()}/**/{x[AnnotationTypes.PLUGIN.value]}", recursive=True))
+            files = list(glob.iglob(f"{x[AnnotationKeys.PATH.value]}/**/{x[AnnotationTypes.PLUGIN.value]}", recursive=True))
             if len(files) == 0:
-                raise FileNotFoundError(f"Unable to find '{x[AnnotationTypes.PLUGIN.value]}' plugin in '{os.getcwd()}'")
+                raise FileNotFoundError(f"Unable to find '{x[AnnotationTypes.PLUGIN.value]}' plugin in '{x[AnnotationKeys.PATH.value]}'")
             else:
                 try:
                     for package in files:

--- a/openvariant/annotation/config_annotation.py
+++ b/openvariant/annotation/config_annotation.py
@@ -33,6 +33,7 @@ class AnnotationKeys(Enum):
     FILE_MAPPING = 'fileMapping'
     FIELD_MAPPING = 'fieldMapping'
     FIELD_VALUE = 'fieldValue'
+    PATH = 'path'
 
 
 class ExcludesKeys(Enum):

--- a/tests/test_annotation/test_builder.py
+++ b/tests/test_annotation/test_builder.py
@@ -187,7 +187,7 @@ class TestBuilder(unittest.TestCase):
         self.assertTrue(issubclass(ctxt, Context))
 
     def test_builder_invalid_plugin(self):
-        plugin_dict = {'type': 'plugin', 'plugin': None, 'field': None}
+        plugin_dict = {'type': 'plugin', 'plugin': None, 'field': None, 'path': None}
 
         with self.assertRaises(FileNotFoundError):
             AnnotationTypesBuilders[AnnotationTypes.PLUGIN.name].value(plugin_dict)


### PR DESCRIPTION
Draft of implementation of new key for plugins in the annotation. ref to 
- #21 

summary: 
- add new key in in `AnnotationKey`class for path
- edit yaml config
- edit plugin search glob given the path.

#TODOs:

- [ ] add tests
- [ ] add documentation

@dmartmillan @CarlosLopezElorduy 

This implementation includes the possibility of adding a parameter "path" to where to find the customized plugins. 

Although I think this solves only part of the problem, since it would accept the path, although we need to understand a way to handle plugins in packages that uses openvariant (i.e. cgi-pipeline)
