### PR TITLE
Add environment variable `OPENVAR_PLUGIN` 

### DIFF
--- a/openvariant/annotation/builder.py
+++ b/openvariant/annotation/builder.py
@@ -249,9 +249,9 @@ def _plugin_builder(x: dict, base_path: str = None) -> PluginBuilder:
         ctxt = _get_plugin_context(mod)
     except ModuleNotFoundError:
         try:
-            files = list(glob.iglob(f"{os.getcwd()}/**/{x[AnnotationTypes.PLUGIN.value]}", recursive=True))
+            files = list(glob.iglob(f"{os.environ['OPENVAR_PLUGIN']}/**/{x[AnnotationTypes.PLUGIN.value]}", recursive=True))
             if len(files) == 0:
-                raise FileNotFoundError(f"Unable to find '{x[AnnotationTypes.PLUGIN.value]}' plugin in '{os.getcwd()}'")
+                raise FileNotFoundError(f"Unable to find '{x[AnnotationTypes.PLUGIN.value]}' plugin in '{os.environ['OPENVAR_PLUGIN']}'")
             else:
                 try:
                     for package in files:
@@ -263,7 +263,7 @@ def _plugin_builder(x: dict, base_path: str = None) -> PluginBuilder:
                         func = _get_plugin_function(mod)
                         ctxt = _get_plugin_context(mod)
                 except (ImportError, AttributeError):
-                    raise ImportError(f"Unable to import 'run' on the plugin.")
+                    raise ImportError("Unable to import 'run' on the plugin.")
         except ModuleNotFoundError:
             raise ModuleNotFoundError(f"Unable to found '{x[AnnotationTypes.PLUGIN.value]}' plugin.")
     except (ImportError, AttributeError) as e:

--- a/openvariant/commands/openvar.py
+++ b/openvariant/commands/openvar.py
@@ -6,6 +6,7 @@ from openvariant.tasks.cat import cat as cat_task
 from openvariant.tasks.count import count as count_task
 from openvariant.tasks.groupby import group_by as group_by_task
 from openvariant.tasks.plugin import PluginActions
+from openvariant.utils.utils import loadEnvironmentVariables
 
 
 @click.group(context_settings={'help_option_names': ['-h', '--help']})
@@ -13,6 +14,7 @@ from openvariant.tasks.plugin import PluginActions
 def openvar():
     """'openvar' is the command-line interface of OpenVariant.
     Parsing and data transformation of multiple input formats."""
+    loadEnvironmentVariables()
     pass
 
 
@@ -106,10 +108,9 @@ def groupby(input_path: str, script: str, where: str, group_by: str, cores: int,
 @openvar.command(name="plugin", short_help='Actions to execute for a plugin: create.')
 @click.argument('action', type=click.Choice(['create']))
 @click.option('--name', '-n', type=click.STRING, help="Name of the plugin.")
-@click.option('--directory', '-d', type=click.STRING, help="Directory to reach the plugin.")
-def plugin(action, name: str or None, directory: str or None):
+def plugin(action, name: str or None):
     """Actions to apply on the plugin system."""
-    PluginActions[action.upper()].value(name, directory)
+    PluginActions[action.upper()].value(name)
 
 
 if __name__ == "__main__":

--- a/openvariant/tasks/plugin.py
+++ b/openvariant/tasks/plugin.py
@@ -8,7 +8,7 @@ from enum import Enum
 from functools import partial
 
 
-def _add_action(name: str, directory: str = None) -> None:
+def _add_action(name: str) -> None:
     """Create a new plugin
 
     It will generate all the required structure for a new plugin (files and folders).
@@ -20,7 +20,7 @@ def _add_action(name: str, directory: str = None) -> None:
     directory : str
         The path to create the plugin.
     """
-    path = directory if directory is not None else os.getcwd()
+    path = os.environ['OPENVAR_PLUGIN']
     if os.path.exists(f"{path}/{name}"):
         raise FileExistsError(f"Directory {path}/{name} already exists.")
     os.mkdir(f"{path}/{name}")

--- a/openvariant/utils/utils.py
+++ b/openvariant/utils/utils.py
@@ -7,9 +7,9 @@ from os.path import basename
 
 ENV_VAR = {
     'OPENVAR_PLUGIN': user_data_dir('openvariant', 'bbglab')
-    }
+}
 
-def loadEnvironmentVariables():
+def loadEnvironmentVariables() -> None:
     """Load environment variable into the environment."""
 
     missing_vars = set(ENV_VAR.keys()).difference(set(os.environ))

--- a/openvariant/utils/utils.py
+++ b/openvariant/utils/utils.py
@@ -1,7 +1,24 @@
 import re
+import os
+from appdirs import user_data_dir
 from fnmatch import fnmatch
 from os.path import basename
 
+
+ENV_VAR = {
+    'OPENVAR_PLUGIN': user_data_dir('openvariant', 'bbglab')
+    }
+
+def loadEnvironmentVariables():
+    """Load environment variable into the environment."""
+
+    missing_vars = set(ENV_VAR.keys()).difference(set(os.environ))
+
+    for env_var in missing_vars:
+        os.environ[env_var] = ENV_VAR[env_var]
+        os.makedirs(ENV_VAR[env_var], exist_ok=True)
+
+    return
 
 def check_extension(ext: str, path: str) -> bool:
     """Check if file matches with the annotation pattern"""

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     keywords='bioinformatics,openvariant,openvar,bbglab',
     packages=find_packages(exclude=["tests.*", "tests"]),
     include_package_data=True,
-    install_requires=['pyyaml', 'tqdm', 'click', 'pyliftover'],
+    install_requires=['pyyaml', 'tqdm', 'click', 'pyliftover', 'appdirs'],
     entry_points={
         'console_scripts': [
             'openvar = openvariant.commands.openvar:openvar',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+from openvariant.utils.utils import loadEnvironmentVariables
+
+loadEnvironmentVariables()


### PR DESCRIPTION
This PR implements the use of an environment variable in Openvariant that stores where the plugin should be search and create.

by default the path is:

```
$HOME/.local/share/openvariant/
```

Given issue 
- #21 

Please feel free to add any comment, suggestion, improvement that can be added to finalize this PR. 