### PR TITLE
18 OpenVariant Dont fail if folderfile permission denied

### DIFF
--- a/docs/examples/cli/introduction_cli.ipynb
+++ b/docs/examples/cli/introduction_cli.ipynb
@@ -4,6 +4,9 @@
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
@@ -16,6 +19,9 @@
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
@@ -31,6 +37,9 @@
    "execution_count": 1,
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
@@ -67,6 +76,9 @@
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
@@ -77,9 +89,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
@@ -98,6 +113,7 @@
       "  -a, --annotations PATH  Annotation path. eg: /path/annotation_vcf.yaml\n",
       "  --header                Show the result header.\n",
       "  -o, --output TEXT       File to write the output.\n",
+      "  --skip                  Skip files and directories that are unreadable.\n",
       "  -h, --help              Show this message and exit.\n"
      ]
     }
@@ -111,6 +127,9 @@
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
@@ -121,9 +140,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
@@ -144,6 +166,7 @@
       "  -c, --cores INTEGER     Maximum processes to run in parallel.\n",
       "  -q, --quite             Don't show the progress.\n",
       "  -o, --output TEXT       File to write the output.\n",
+      "  --skip                  Skip files and directories that are unreadable.\n",
       "  -h, --help              Show this message and exit.\n"
      ]
     }
@@ -157,6 +180,9 @@
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
@@ -167,9 +193,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
@@ -194,6 +223,7 @@
       "  -c, --cores INTEGER     Maximum processes to run in parallel.\n",
       "  -q, --quite             Don't show the progress.\n",
       "  -o, --output TEXT       File to write the output.\n",
+      "  --skip                  Skip files and directories that are unreadable.\n",
       "  -h, --help              Show this message and exit.\n"
      ]
     }
@@ -207,6 +237,9 @@
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
@@ -217,9 +250,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
@@ -234,9 +270,8 @@
       "  Actions to apply on the plugin system.\n",
       "\n",
       "Options:\n",
-      "  -n, --name TEXT       Name of the plugin.\n",
-      "  -d, --directory TEXT  Directory to reach the plugin.\n",
-      "  -h, --help            Show this message and exit.\n"
+      "  -n, --name TEXT  Name of the plugin.\n",
+      "  -h, --help       Show this message and exit.\n"
      ]
     }
    ],
@@ -248,23 +283,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/docs/examples/find_files/find_files_with_directory_path.ipynb
+++ b/docs/examples/find_files/find_files_with_directory_path.ipynb
@@ -13,19 +13,31 @@
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "A Simple example on how find files task works for a directory path."
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "A Simple example on how find files task works for a directory path."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from os import getcwd\n",
@@ -33,16 +45,19 @@
     "from openvariant import findfiles\n",
     "\n",
     "dataset_folder = f'{dirname(getcwd())}/datasets/sample1'"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "It will get any type of file that matches with any _annotation_ file that is on the same folder or in a child folder.\n",
     "\n",
@@ -50,19 +65,23 @@
     "\n",
     "- `base_path` - Base path of _input_ folder.\n",
     "- `annotation_path` - Path of _annotation_ file.\n",
+    "- `skip_files` - Skip unreadable files and directories.\n",
     "\n",
     "As we see, the output has two types of pattern `*.vcf.gz` and `*.maf.gz`.\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -94,31 +113,37 @@
     "    print(f'File path: {file_path}')\n",
     "    print(f'Annotation object: {annotation}')\n",
     "    print(\"-------------------------------------\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "In the following example, we will get files with a fixed _Annotation_ file.\n",
     "\n",
     "All the files that we will be able to detect will follow the pattern described on annotations."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -140,13 +165,7 @@
     "    print(f'File path: {file_path}')\n",
     "    print(f'Annotation object: {annotation}')\n",
     "    print(\"-------------------------------------\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   }
  ],
  "metadata": {
@@ -166,9 +185,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/docs/examples/find_files/find_files_with_file_path.ipynb
+++ b/docs/examples/find_files/find_files_with_file_path.ipynb
@@ -2,31 +2,46 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "source": [
-    "# With file path"
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "# With file path"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "A simple example on how find files task works for a file path."
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "A simple example on how find files task works for a file path."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from os import getcwd\n",
@@ -34,16 +49,19 @@
     "from openvariant import findfiles\n",
     "\n",
     "dataset_file = f'{dirname(getcwd())}/datasets/sample1/5a3a743.wxs.maf.gz'"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "As it occurs on the [directory path examples](find_files_with_directory_path.ipynb), it will get the file and its corresponding _Annotation_ object.\n",
     "\n",
@@ -51,19 +69,23 @@
     "\n",
     "- `base_path` - Base path of _input_ file.\n",
     "- `annotation_path` - Path of _annotation_ file.\n",
+    "- `skip_files` - Skip unreadable files and directories.\n",
     "\n",
     "It will only get one file as an _output_, the file that is passed as a parameter. In case that there's any _annotation_ file that matches with the file's pattern, it won't generate any output."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -80,31 +102,37 @@
     "    print(f'File path: {file_path}')\n",
     "    print(f'Annotation object: {annotation}')\n",
     "    print(\"-------------------------------------\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "It is possible to pass the _annotation_ file as a parameter of the function.\n",
     "\n",
     "It will generate the same output as it did before, and if the _annotation_ file doesn't match with the _input_ file it will not generate any output."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -123,31 +151,37 @@
     "    print(f'File path: {file_path}')\n",
     "    print(f'Annotation object: {annotation}')\n",
     "    print(\"-------------------------------------\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "As it occurs on the [directory path examples](find_files_with_directory_path.ipynb), it will get the file and its corresponding _Annotation_ object.\n",
     "\n",
     "It will only get one file as an output, the file that is passed as a parameter. In case that there's any _annotation_ file that matches with the file's pattern, it won't generate any output."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -164,34 +198,28 @@
     "    print(f'File path: {file_path}')\n",
     "    print(f'Annotation object: {annotation}')\n",
     "    print(\"-------------------------------------\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/docs/examples/tasks/cat.ipynb
+++ b/docs/examples/tasks/cat.ipynb
@@ -2,31 +2,46 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "source": [
-    "# _Cat_"
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "# _Cat_"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "A simple example where we can find how **cat** task works. This task is able with command-line."
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "A simple example where we can find how **cat** task works. This task is able with command-line."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from os import getcwd\n",
@@ -34,16 +49,19 @@
     "from openvariant import cat\n",
     "\n",
     "dataset_folder = f'{dirname(getcwd())}/datasets/sample2'"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "`cat` task allows us to show on the standard output the parsed result. It has the following parameters:\n",
     "\n",
@@ -51,18 +69,22 @@
     "- `annotation_path` - Path of the _annotation_ path.\n",
     "- `where` - Filter expression.\n",
     "- `header_show` - Show header on the result.\n",
-    "- `output` - File path to save the output result."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+    "- `output` - File path to save the output result.\n",
+    "- `skip_files` - Skip unreadable files and directories."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -92,16 +114,19 @@
    ],
    "source": [
     "cat(base_path=dataset_folder)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "One of the parameters on `cat` task is `where`. You will be able to apply a conditional filter. The possible operations can be:\n",
     "\n",
@@ -113,17 +138,20 @@
     "+ `>` - More than.\n",
     "\n",
     "One example of this parameter is the following one:"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -137,34 +165,28 @@
    ],
    "source": [
     "cat(base_path=dataset_folder, where=\"SYMBOL == 'ATAD3C'\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/docs/examples/tasks/count.ipynb
+++ b/docs/examples/tasks/count.ipynb
@@ -4,6 +4,9 @@
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
@@ -16,6 +19,9 @@
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
@@ -29,6 +35,9 @@
    "execution_count": 1,
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
@@ -47,6 +56,9 @@
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
@@ -60,6 +72,7 @@
     "- `where` - Filter expression.\n",
     "- `cores` - Maximum processes to run in parallel.\n",
     "- `quite` - Do not show the progress meanwhile the parsing is running.\n",
+    "- `skip_files` - Skip unreadable files and directories.\n",
     "\n",
     "On the following example we can see a general case of `count` task:"
    ]
@@ -69,6 +82,9 @@
    "execution_count": 2,
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
@@ -91,6 +107,9 @@
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
@@ -113,6 +132,9 @@
    "execution_count": 3,
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
@@ -136,23 +158,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/docs/examples/tasks/group_by.ipynb
+++ b/docs/examples/tasks/group_by.ipynb
@@ -2,31 +2,46 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "source": [
-    "# _Group by_"
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "# _Group by_"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "A simple example where we can find how **group by** task works. This task is able with command-line.\n"
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "A simple example where we can find how **group by** task works. This task is able with command-line.\n"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from os.path import dirname\n",
@@ -35,16 +50,19 @@
     "\n",
     "dataset_folder = f'{dirname(getcwd())}/datasets/sample2'\n",
     "annotation_path = f'{dirname(getcwd())}/datasets/sample2/annotation.yaml'"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "`group_by` task allows us to group the rows depending on the value of an output field.\n",
     "\n",
@@ -56,19 +74,23 @@
     "- `cores` - Maximum processes to run in parallel.\n",
     "- `quite` - Do not show the progress meanwhile the parsing is running.\n",
     "- `header` - Show header on the result.\n",
+    "- `skip_files` - Skip unreadable files and directories.\n",
     "\n",
     "On the following example we can see a general case for `group by` task:"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -107,16 +129,19 @@
     "    for row in values:\n",
     "        print(row)\n",
     "    print(\"\\n\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "One of the parameters on `count` task is `where`. You will be able to apply a conditional filter. The possible operations can be:\n",
     "\n",
@@ -128,17 +153,20 @@
     "+ `>` - More than.\n",
     "\n",
     "One example of this parameter is the following one:"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -161,29 +189,35 @@
     "    for row in values:\n",
     "        print(row)\n",
     "    print(\"\\n\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Also, on `group by` task, there is `script` parameter which will allow to the user to execute a command shell on the parsed result. In the following example we can see how many characters there are in each group of the parsed output:"
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "Also, on `group by` task, there is `script` parameter which will allow to the user to execute a command shell on the parsed result. In the following example we can see how many characters there are in each group of the parsed output:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -206,34 +240,28 @@
     "    for row in values:\n",
     "        print(row)\n",
     "    print(\"\\n\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/docs/examples/variant/read.ipynb
+++ b/docs/examples/variant/read.ipynb
@@ -2,31 +2,46 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "source": [
-    "# Read"
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "# Read"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "A simple example on how **Variant** can read and how can be treated."
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "A simple example on how **Variant** can read and how can be treated."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from os import getcwd\n",
@@ -35,16 +50,19 @@
     "\n",
     "dataset_file = f'{dirname(getcwd())}/datasets/sample1/22f5b2f.wxs.maf.gz'\n",
     "annotation_file = f'{dirname(getcwd())}/datasets/sample1/annotation_maf.yaml'"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "`Annotation` object generated from _annotation_ file. Parameters:\n",
     "\n",
@@ -54,6 +72,7 @@
     "\n",
     "- `path` - Path of _input_ file.\n",
     "- `annotation` - Annotation object which _input_ will be parsed.\n",
+    "- `skip_files` - Skip unreadable files and directories.\n",
     "\n",
     "One of the main functions of _Variant_ is `read`.It will generate an iterator to scan the parsed file.\n",
     "\n",
@@ -64,17 +83,20 @@
     "\n",
     "\n",
     "In this example, it will get the 10 first lines of parsed files through an _annotation_ file."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -101,31 +123,37 @@
     "    print(f'Line {n_line}: {line}')\n",
     "    if n_line == 9:\n",
     "        break"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "As we can see in the output each line is a `dict` where the `key` is the field of the parsed result and the `value` is the value in that cell.\n",
     "\n",
     "**Variant** has different attributes than we can explore:"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -139,16 +167,19 @@
    "source": [
     "print('Headers: ', result.header)\n",
     "print('Input file: ', result.path)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Also, we can check the _Annotation_ which input file was parsed.\n",
     "\n",
@@ -160,17 +191,20 @@
     "+ Excludes - `excludes`\n",
     "+ Patterns - `patterns`\n",
     "+ Structure - `structure`"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -182,16 +216,19 @@
    ],
    "source": [
     "print(result.annotation.annotations)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "One of the parameter to `read` function is `where`. You will be able to apply a conditional filter. The possible operations can be:\n",
     "\n",
@@ -203,17 +240,20 @@
     "+ `>` - More than.\n",
     "\n",
     "One example of this parameter is the following one:"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -229,41 +269,50 @@
     "\n",
     "for n_line, line in enumerate(result.read(where=\"POSITION == 186112\")):\n",
     "    print(f'{line}')"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Also, `read` allows `group_key` as a parameter which it will group rows depending on its value."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "**Variant** can be combined with `findfiles` as it shows the following example. It will print the 3 first lines of each input file."
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "**Variant** can be combined with `findfiles` as it shows the following example. It will print the 3 first lines of each input file."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -330,34 +379,28 @@
     "        if n_line == 2:\n",
     "            print(\"\\n\")\n",
     "            break"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/docs/examples/variant/save.ipynb
+++ b/docs/examples/variant/save.ipynb
@@ -2,31 +2,46 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "source": [
-    "# Save"
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "# Save"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "A simple example on how **Variant** can save the output.\n"
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "A simple example on how **Variant** can save the output.\n"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from os import getcwd\n",
@@ -35,16 +50,19 @@
     "\n",
     "dataset_file = f'{dirname(getcwd())}/datasets/sample1/22f5b2f.wxs.maf.gz'\n",
     "annotation_file = f'{dirname(getcwd())}/datasets/sample1/annotation_maf.yaml'"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "`Annotation` object generated from _annotation_ file. Parameters:\n",
     "\n",
@@ -54,6 +72,7 @@
     "\n",
     "- `path` - Path of _input_ file.\n",
     "- `annotation` - Annotation object which _input_ will be parsed.\n",
+    "- `skip_files` - Skip unreadable files and directories.\n",
     "\n",
     "One of the main functions of _Variant_ is `read`. It will generate an iterator to scan the parsed file.\n",
     "\n",
@@ -67,17 +86,20 @@
     "\n",
     "\n",
     "In this example, it will save the parsed input in an _output_ file."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "annotation = Annotation(annotation_file)\n",
@@ -85,29 +107,35 @@
     "\n",
     "output_file = f'{dirname(getcwd())}/datasets/sample1/output.tsv'\n",
     "result.save(file_path=output_file, display_header=True)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "It is also possible to combine `save` function with `findfiles` which will find any file and then save the parsed output appending it in a single file."
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "It is also possible to combine `save` function with `findfiles` which will find any file and then save the parsed output appending it in a single file."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from openvariant import findfiles\n",
@@ -126,44 +154,41 @@
     "        result.save(output_file_append, mode=\"a\")\n",
     "    except NameError:\n",
     "        pass"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/docs/user_guide/cli.rst
+++ b/docs/user_guide/cli.rst
@@ -42,11 +42,12 @@ Concatenate parsed files on the standard output. For these options the parameter
 * ``-w,--where`` - Condition expression.
 * ``-a,--annotations`` - Annotation path.
 * ``--header`` - Show headers on the result.
+* ``--skip`` - Skip unreadable files and directories.
 
 .. code-block:: bash
 
     # Example
-    openvar cat /project/datasets -w "SCORE >= 5" -a /project/annotation.yaml  --header
+    openvar cat /project/datasets -w "SCORE >= 5" -a /project/annotation.yaml  --header --skip
 
 
 Count command
@@ -60,11 +61,12 @@ Number of rows that matches a specific condition. The parameters are the followi
 * ``-a,--annotations`` - Annotation path.
 * ``-c,--cores`` - Maximum processes to run in parallel.
 * ``-q,--quite`` - Don't show the progress.
+* ``--skip`` - Skip unreadable files and directories.
 
 .. code-block:: bash
 
     # Example
-    openvar count /project/datasets -w "REF >= 5034" -g COUNTRY -a /project/annotation.yaml -c 10 -q
+    openvar count /project/datasets -w "REF >= 5034" -g COUNTRY -a /project/annotation.yaml -c 10 -q --skip
 
 Group by command
 #################
@@ -77,11 +79,12 @@ Number of rows that matches a specific condition. The parameters are the followi
 * ``-a,--annotations`` - Annotation path.
 * ``-c,--cores`` - Maximum processes to run in parallel.
 * ``-q,--quite`` - Don't show the progress.
+* ``--skip`` - Skip unreadable files and directories.
 
 .. code-block:: bash
 
     # Example
-    openvar count /project/datasets -w "REF >= 5034" -g COUNTRY -a /project/annotation.yaml -c 10 -q
+    openvar count /project/datasets -w "REF >= 5034" -g COUNTRY -a /project/annotation.yaml -c 10 -q --skip
 
 Plugin command
 ################

--- a/openvariant/commands/openvar.py
+++ b/openvariant/commands/openvar.py
@@ -24,9 +24,10 @@ def openvar():
               help="Annotation path. eg: /path/annotation_vcf.yaml")
 @click.option('--header', is_flag=True, help="Show the result header.")
 @click.option('--output', '-o', default=None, help="File to write the output.")
-def cat(input_path: str, where: str or None, annotations: str or None, header: bool, output: str or None):
+@click.option('--skip', is_flag=True, help="Skip files and directories that are unreadable.")
+def cat(input_path: str, where: str or None, annotations: str or None, header: bool, output: str or None, skip: bool):
     """Print the parsed files on the stdout/"output"."""
-    cat_task(input_path, annotations, where, header, output)
+    cat_task(input_path, annotations, where, header, output, skip)
 
 
 @openvar.command(name="count", short_help='Number of rows that matches a specified criterion.')
@@ -38,10 +39,11 @@ def cat(input_path: str, where: str or None, annotations: str or None, header: b
 @click.option('--cores', '-c', type=click.INT, default=cpu_count(), help='Maximum processes to run in parallel.')
 @click.option('--quite', '-q', is_flag=True, help="Don't show the progress.")
 @click.option('--output', '-o', default=None, help="File to write the output.")
+@click.option('--skip', is_flag=True, help="Skip files and directories that are unreadable.")
 def count(input_path: str, where: str, group_by: str, cores: int, quite: bool, annotations: str or None,
-          output: str or None) -> None:
+          output: str or None, skip: bool) -> None:
     """Print on the stdout/"output" the number of rows that meets the criteria."""
-    result = count_task(input_path, annotations, group_by=group_by, where=where, cores=cores, quite=quite)
+    result = count_task(input_path, annotations, group_by=group_by, where=where, cores=cores, quite=quite, skip_files=skip)
     out_file = None
     if output:
         out_file = open(output, "w")
@@ -74,14 +76,15 @@ def count(input_path: str, where: str, group_by: str, cores: int, quite: bool, a
 @click.option('--cores', '-c', type=click.INT, default=cpu_count(), help='Maximum processes to run in parallel.')
 @click.option('--quite', '-q', is_flag=True, help="Don't show the progress.")
 @click.option('--output', '-o', help="File to write the output.", default=None)
+@click.option('--skip', is_flag=True, help="Skip files and directories that are unreadable.")
 def groupby(input_path: str, script: str, where: str, group_by: str, cores: int, quite: bool, annotations: str or None,
-            header: bool, show: bool, output: str or None):
+            header: bool, show: bool, output: str or None, skip: bool):
     """Print on the stdout/"output" the parsed files group by a specified field."""
     out_file = None
     if output:
         out_file = open(output, 'w')
     for group_key, group_result, command in group_by_task(input_path, annotations, script, key_by=group_by, where=where,
-                                                          cores=cores, quite=quite, header=header):
+                                                          cores=cores, quite=quite, header=header, skip_files=skip):
         for r in group_result:
             if command:
                 if output:

--- a/openvariant/find_files/find_files.py
+++ b/openvariant/find_files/find_files.py
@@ -54,9 +54,9 @@ def _scan_files(base_path: str, annotation: Annotation, fix: bool, skip_files: b
                 raise PermissionError(f"Permission denied on {file_path}")
     else:
         if skip_files:
-            warnings.warn(f"Unable to open {base_path}, it's not a file nor a directory.", UserWarning)
+            warnings.warn(f"Unable to open {base_path}, it is neither a file nor a directory, or it does not exist.", UserWarning)
         else:
-            raise PermissionError(f"Unable to open {base_path}, it's not a file nor a directory.")
+            raise FileNotFoundError(f"Unable to open {base_path}, it is neither a file nor a directory, or it does not exist.")
 
 
 

--- a/openvariant/find_files/find_files.py
+++ b/openvariant/find_files/find_files.py
@@ -7,6 +7,7 @@ import glob
 from os import listdir
 from os.path import isfile, join, isdir, dirname
 from typing import Generator
+import warnings
 
 from openvariant.annotation.annotation import Annotation
 from openvariant.annotation.config_annotation import ANNOTATION_EXTENSION
@@ -23,7 +24,7 @@ def _get_annotation(file_path, annotation):
             raise AttributeError("Unable to parse annotation file, check its location.")
 
 
-def _scan_files(base_path: str, annotation: Annotation, fix: bool):
+def _scan_files(base_path: str, annotation: Annotation, fix: bool, skip_files: bool):
     """Recursive exploration from a base path"""
     if isdir(base_path):
         if not fix:
@@ -34,22 +35,32 @@ def _scan_files(base_path: str, annotation: Annotation, fix: bool):
         for file_name in list_files:
             file_path = join(base_path, file_name)
             try:
-                for f, a in _scan_files(file_path, annotation, fix):
+                for f, a in _scan_files(file_path, annotation, fix, skip_files):
                     yield f, a
-            except PermissionError as e:
-                raise PermissionError(f"Unable to open {file_name}: {e}")
+            except PermissionError:
+                if skip_files:
+                    warnings.warn(f"Permission denied on {file_path}", UserWarning)
+                else:
+                    raise PermissionError(f"Permission denied on {file_path}")
     elif isfile(base_path):
         file_path = base_path
         try:
             for f, a in _get_annotation(file_path, annotation):
                 yield f, a
-        except PermissionError as e:
-            raise PermissionError(f"Unable to open {base_path}: {e}")
+        except PermissionError:
+            if skip_files:
+                warnings.warn(f"Permission denied on {file_path}", UserWarning)
+            else:
+                raise PermissionError(f"Permission denied on {file_path}")
     else:
-        raise FileNotFoundError(f"Unable to open {base_path}, it's not a file nor a directory.")
+        if skip_files:
+            warnings.warn(f"Unable to open {base_path}, it's not a file nor a directory.", UserWarning)
+        else:
+            raise PermissionError(f"Unable to open {base_path}, it's not a file nor a directory.")
 
 
-def _find_files(base_path: str, annotation: Annotation or None, fix: bool) -> Generator[str, Annotation, None]:
+
+def _find_files(base_path: str, annotation: Annotation or None, fix: bool, skip_files: bool) -> Generator[str, Annotation, None]:
     """Recursive exploration from a base path distinct if there's a fix annotation or no"""
     if not fix:
         if isfile(base_path):
@@ -59,11 +70,11 @@ def _find_files(base_path: str, annotation: Annotation or None, fix: bool) -> Ge
         for annotation_file in glob.iglob(join(annotation_path, "*.{}".format(ANNOTATION_EXTENSION))):
             annotation = Annotation(annotation_file)
             
-    for f, a in _scan_files(base_path, annotation, fix):
+    for f, a in _scan_files(base_path, annotation, fix, skip_files):
         yield f, a
 
 
-def findfiles(base_path: str, annotation_path: str or None = None) -> Generator[str, Annotation, None]:
+def findfiles(base_path: str, annotation_path: str or None = None, skip_files: bool = False) -> Generator[str, Annotation, None]:
     """Get each file and its proper annotation object.
 
     Parameters
@@ -72,6 +83,8 @@ def findfiles(base_path: str, annotation_path: str or None = None) -> Generator[
         Base path of input folder/file.
     annotation_path : str or None
         Path of annotation file.
+    skip_files : bool
+        Skip unreadable files and directories.
 
     Yields
     -------
@@ -81,5 +94,5 @@ def findfiles(base_path: str, annotation_path: str or None = None) -> Generator[
         The proper schema of each input file.
     """
     annotation, fix = (Annotation(annotation_path), True) if annotation_path is not None else (None, False)
-    for f, a in _find_files(base_path, annotation, fix):
+    for f, a in _find_files(base_path, annotation, fix, skip_files):
         yield f, a

--- a/openvariant/tasks/cat.py
+++ b/openvariant/tasks/cat.py
@@ -16,7 +16,7 @@ def _format_line(line: List[str], out_format: str) -> str:
 
 
 def cat(base_path: str, annotation_path: str or None = None, where: str = None, header_show: bool = True,
-        output: str or None = None) -> None:
+        output: str or None = None, skip_files: bool = False) -> None:
     """Print on the stdout/"output" the parsed files.
 
     It will parse the input files with its proper annotation schema, and it'll show the result on the stdout.
@@ -34,12 +34,14 @@ def cat(base_path: str, annotation_path: str or None = None, where: str = None, 
         Shows header on the output.
     output : str or None
         Save output on a file.
+    skip_files : bool
+        Skip unreadable files and directories.
     """
     out_file = None
     if output:
         out_file = open(output, "w")
-    for file, annotation in findfiles(base_path, annotation_path):
-        result = Variant(file, annotation)
+    for file, annotation in findfiles(base_path, annotation_path, skip_files):
+        result = Variant(file, annotation, skip_files)
         header = result.header
         if header_show:
             if output:

--- a/openvariant/tasks/count.py
+++ b/openvariant/tasks/count.py
@@ -16,13 +16,13 @@ from openvariant.find_files.find_files import findfiles
 from openvariant.variant.variant import Variant
 
 
-def _count_task(selection: [str, str], group_by: str, where: str) -> Tuple[int, Union[dict, None]]:
+def _count_task(selection: [str, str], group_by: str, where: str, skip_files: bool) -> Tuple[int, Union[dict, None]]:
     """Main functionality for count task"""
 
     i = 0
     input_file, input_annotations = selection
     annotation = Annotation(input_annotations)
-    result = Variant(input_file, annotation)
+    result = Variant(input_file, annotation, skip_files)
 
     if group_by is None:
         for _ in result.read(where=where):
@@ -42,7 +42,7 @@ def _count_task(selection: [str, str], group_by: str, where: str) -> Tuple[int, 
 
 
 def count(base_path: str, annotation_path: str or None, group_by: str = None, where: str = None,
-          cores: int = cpu_count(), quite: bool = False) -> Tuple[int, Union[None, dict]]:
+          cores: int = cpu_count(), quite: bool = False, skip_files: bool = False) -> Tuple[int, Union[None, dict]]:
     """Print on the stdout the count result.
 
     It'll parse the input files with its proper annotation schema, and it'll show the count result on the stdout.
@@ -62,6 +62,8 @@ def count(base_path: str, annotation_path: str or None, group_by: str = None, wh
         Discard progress bar.
     cores : int
         Number of cores to parallelize the task.
+    skip_files : bool
+        Skip unreadable files and directories.
 
     Returns
     ----------
@@ -76,7 +78,7 @@ def count(base_path: str, annotation_path: str or None, group_by: str = None, wh
 
     with Pool(cores) as pool:
         groups = {}
-        task = partial(_count_task, group_by=group_by, where=where)
+        task = partial(_count_task, group_by=group_by, where=where, skip_files=skip_files)
         map_method = pool.imap_unordered if len(selection) > 1 else map
         total = 0
         for c, g in tqdm(map_method(task, selection),

--- a/openvariant/tasks/groupby.py
+++ b/openvariant/tasks/groupby.py
@@ -49,7 +49,7 @@ def _group(base_path: str, annotation_path: str or None, key_by: str) -> List[Tu
     return results_by_groups
 
 
-def _group_by_task(selection, where=None, key_by=None, script='', header=False) -> Tuple[str, List, bool]:
+def _group_by_task(selection, where=None, key_by=None, script='', header=False, skip_files=False) -> Tuple[str, List, bool]:
     """Main functionality for group by task"""
     group_key, group_values = selection
 
@@ -59,7 +59,7 @@ def _group_by_task(selection, where=None, key_by=None, script='', header=False) 
             for value in group_values:
                 input_file = value[0]
                 annotation = Annotation(value[1])
-                result = Variant(input_file, annotation)
+                result = Variant(input_file, annotation, skip_files)
                 columns = result.annotation.columns if len(result.annotation.columns) != 0 else result.header
 
                 if header:
@@ -83,7 +83,7 @@ def _group_by_task(selection, where=None, key_by=None, script='', header=False) 
             for value in group_values:
                 input_file = value[0]
                 annotation = Annotation(value[1])
-                result = Variant(input_file, annotation)
+                result = Variant(input_file, annotation, skip_files)
                 columns = result.annotation.columns if len(result.annotation.columns) != 0 else result.header
 
                 if header:
@@ -116,7 +116,7 @@ def _group_by_task(selection, where=None, key_by=None, script='', header=False) 
 
 
 def group_by(base_path: str, annotation_path: str or None, script: str or None, key_by: str, where: str or None = None,
-             cores=cpu_count(), quite=False, header: bool = False) -> Generator[Tuple[str, List, bool], None, None]:
+             cores=cpu_count(), quite=False, header: bool = False, skip_files: bool = False) -> Generator[Tuple[str, List, bool], None, None]:
     """Print on the stdout the group by result.
 
     It'll parse the input files with its proper annotation schema, and it'll show the parsed result separated for each
@@ -141,6 +141,9 @@ def group_by(base_path: str, annotation_path: str or None, script: str or None, 
         Number of cores to parallelize the task.
     header : bool
         Number of cores to parallelize the task.
+    skip_files : bool
+        Skip unreadable files and directories.
+
     Returns
     ----------
     int
@@ -150,7 +153,7 @@ def group_by(base_path: str, annotation_path: str or None, script: str or None, 
     """
     selection = _group(base_path, annotation_path, key_by)
     with Pool(cores) as pool:
-        task = partial(_group_by_task, where=where, key_by=key_by, script=script, header=header)
+        task = partial(_group_by_task, where=where, key_by=key_by, script=script, header=header, skip_files=skip_files)
         map_method = map if cores == 1 or len(selection) <= 1 else pool.imap_unordered
 
         for group_key, group_result, command in tqdm(

--- a/openvariant/variant/variant.py
+++ b/openvariant/variant/variant.py
@@ -159,7 +159,7 @@ class Variant:
             Save parsed files on specified location.
     """
 
-    def __init__(self, path: str, annotation: Annotation, skip_files: bool = False) -> None:
+    def __init__(self, path: str, annotation: Annotation, skip_files: bool) -> None:
         """
         Inits Variant with files path and Annotation object
 
@@ -169,6 +169,8 @@ class Variant:
             A string path where files to parse are located (could be directory or a single file).
         annotation : Annotation
             Object to describe the schema of parsed files.
+        skip_files : bool
+            Skip unreadable files and directories.
         """
         if path is None or path == '' or not isfile(path):
             raise ValueError('Invalid path, must be a file')

--- a/openvariant/variant/variant.py
+++ b/openvariant/variant/variant.py
@@ -159,7 +159,7 @@ class Variant:
             Save parsed files on specified location.
     """
 
-    def __init__(self, path: str, annotation: Annotation, skip_files: bool) -> None:
+    def __init__(self, path: str, annotation: Annotation, skip_files: bool = False) -> None:
         """
         Inits Variant with files path and Annotation object
 

--- a/openvariant/variant/variant.py
+++ b/openvariant/variant/variant.py
@@ -38,7 +38,7 @@ def _open_file(file_path: str, mode='r+b'):
     return mm, file
 
 
-def _base_parser(mm_obj: mmap, file_path: str, delimiter: str) -> Generator[int, str, None]:
+def _base_parser(mm_obj: mmap, file_path: str, delimiter: str, skip_files: bool) -> Generator[int, str, None]:
     """Cleaning comments and irrelevant data"""
     try:
         if file_path.endswith('gz') or file_path.endswith('bgz'):
@@ -46,20 +46,26 @@ def _base_parser(mm_obj: mmap, file_path: str, delimiter: str) -> Generator[int,
     except KeyError:
         raise KeyError(f"'{delimiter}' key not found.")
 
-    for l_num, line in enumerate(iter(mm_obj.readline, b'')):
-        line = line.decode('utf-8')
-        row_line = line.split(AnnotationDelimiter[delimiter].value)
-        row_line = list(map(lambda w: w.replace("\n", ""), row_line))
+    try:
+        for l_num, line in enumerate(iter(mm_obj.readline, b'')):
+            line = line.decode('utf-8')
+            row_line = line.split(AnnotationDelimiter[delimiter].value)
+            row_line = list(map(lambda w: w.replace("\n", ""), row_line))
 
-        if len(row_line) == 0:
-            continue
+            if len(row_line) == 0:
+                continue
 
-        # Skip comments
-        if (row_line[0].startswith('#') or row_line[0].startswith('##') or row_line[0].startswith('browser') or
-            row_line[0].startswith('track')) and not row_line[0].startswith('#CHROM'):
-            continue
+            # Skip comments
+            if (row_line[0].startswith('#') or row_line[0].startswith('##') or row_line[0].startswith('browser') or
+                row_line[0].startswith('track')) and not row_line[0].startswith('#CHROM'):
+                continue
 
-        yield l_num, row_line
+            yield l_num, row_line
+    except Exception as e:
+        if skip_files:
+            warnings.warn(f"Warning: unable to parse {file_path}: {e}.", UserWarning)
+        else:
+            raise e
 
 
 def _exclude(line: dict, excludes: dict) -> bool:
@@ -153,7 +159,7 @@ class Variant:
             Save parsed files on specified location.
     """
 
-    def __init__(self, path: str, annotation: Annotation) -> None:
+    def __init__(self, path: str, annotation: Annotation, skip_files: bool = False) -> None:
         """
         Inits Variant with files path and Annotation object
 
@@ -174,6 +180,7 @@ class Variant:
         self._annotation: Annotation = annotation
         self._header: List[str] = list(annotation.annotations.keys()) if len(annotation.columns) == 0 \
             else annotation.columns
+        self.skip_files = skip_files
 
     def _unify(self, base_path: str, annotation: Annotation, group_by: str = None, display_header: bool = True) \
             -> Generator[dict, None, None]:
@@ -191,72 +198,79 @@ class Variant:
         if not any(matches):
             raise NameError("Annotation patterns don't match with input file.")
 
-        self.mm, self.file = _open_file(file_path, "rb")
-        for lnum, line in _base_parser(self.mm, file_path, annotation.delimiter):
-            try:
-                if header is None:
-                    header, row_header = _extract_header(file_path, line, annotation)
-                    if not display_header:
-                        continue
-                    row = row_header
-                    yield row
-                else:
-                    line_dict = {}
-                    row, plugin_values, mapping_values = {}, {}, {}
-                    for head in annotation.annotations.keys():
-                        type_ann, value, func = header[head]
-                        if type_ann == AnnotationTypes.PLUGIN.name:
-                            plugin_values[head] = header[head]
-                        elif type_ann == AnnotationTypes.MAPPING.name:
-                            mapping_values[head] = header[head]
-                        elif type_ann == AnnotationTypes.INTERNAL.name:
-                            if len(value[0]) == 1:
-                                pos = list(value[0].values())[0]
-                                value = line[pos] if value is not None else None
-                            elif len(value[0]) == 0:
-                                value = line[pos] if value[1] is not None else None 
-                            else:
-                                pos = {}
-                                for val, position in value[0].items():
-                                    pos.update({val: line[position]})
-                                value = value[1].format(**pos)
+        try:
+            self.mm, self.file = _open_file(file_path, "rb")
 
-                            line_dict[head] = _parse_field(value, func)
-                        else:
-                            line_dict[head] = _parse_field(value, func)
-
-                    for head, mapping in mapping_values.items():
-                        _, builder_mapping, func = mapping
-                        line_dict[head] = _parse_mapping_field(builder_mapping, line_dict, func)
-                    for head, plug in plugin_values.items():
-                        _, ctxt_plugin, func_plugin = plug
-                        line_dict[head] = _parse_plugin_field(line_dict, head, file_path, ctxt_plugin, func_plugin)
-
-                    for k in annotation.columns:
-                        row[k] = line_dict[k].format(**line_dict)
-
-                    if group_by is not None and group_by not in annotation.columns:
-                        try:
-                            row[group_by] = line_dict[group_by].format(**line_dict)
-                        except KeyError as e:
-                            raise KeyError(f"Unable to find group by: {e}. Check annotation for {file_path} file")
-
-                    if row and not _exclude(line_dict, annotation.excludes):
+            for lnum, line in _base_parser(self.mm, file_path, annotation.delimiter, self.skip_files):
+                try:
+                    if header is None:
+                        header, row_header = _extract_header(file_path, line, annotation)
+                        if not display_header:
+                            continue
+                        row = row_header
                         yield row
-            except IndexError as e:
-                if line == ['']:
-                    warnings.warn(f"Warning: empty line {lnum} on {file_path}.", UserWarning)
-                    pass
-                else:
+                    else:
+                        line_dict = {}
+                        row, plugin_values, mapping_values = {}, {}, {}
+                        for head in annotation.annotations.keys():
+                            type_ann, value, func = header[head]
+                            if type_ann == AnnotationTypes.PLUGIN.name:
+                                plugin_values[head] = header[head]
+                            elif type_ann == AnnotationTypes.MAPPING.name:
+                                mapping_values[head] = header[head]
+                            elif type_ann == AnnotationTypes.INTERNAL.name:
+                                if len(value[0]) == 1:
+                                    pos = list(value[0].values())[0]
+                                    value = line[pos] if value is not None else None
+                                elif len(value[0]) == 0:
+                                    value = line[pos] if value[1] is not None else None
+                                else:
+                                    pos = {}
+                                    for val, position in value[0].items():
+                                        pos.update({val: line[position]})
+                                    value = value[1].format(**pos)
+
+                                line_dict[head] = _parse_field(value, func)
+                            else:
+                                line_dict[head] = _parse_field(value, func)
+
+                        for head, mapping in mapping_values.items():
+                            _, builder_mapping, func = mapping
+                            line_dict[head] = _parse_mapping_field(builder_mapping, line_dict, func)
+                        for head, plug in plugin_values.items():
+                            _, ctxt_plugin, func_plugin = plug
+                            line_dict[head] = _parse_plugin_field(line_dict, head, file_path, ctxt_plugin, func_plugin)
+
+                        for k in annotation.columns:
+                            row[k] = line_dict[k].format(**line_dict)
+
+                        if group_by is not None and group_by not in annotation.columns:
+                            try:
+                                row[group_by] = line_dict[group_by].format(**line_dict)
+                            except KeyError as e:
+                                raise KeyError(f"Unable to find group by: {e}. Check annotation for {file_path} file")
+
+                        if row and not _exclude(line_dict, annotation.excludes):
+                            yield row
+                except IndexError as e:
+                    if line == ['']:
+                        warnings.warn(f"Warning: empty line {lnum} on {file_path}.", UserWarning)
+                        pass
+                    else:
+                        self.mm.close()
+                        self.file.close()
+                        raise ValueError(f"Error parsing line: {lnum} {file_path}: {e}")
+                except (ValueError, KeyError) as e:
                     self.mm.close()
                     self.file.close()
                     raise ValueError(f"Error parsing line: {lnum} {file_path}: {e}")
-            except (ValueError, KeyError) as e:
-                self.mm.close()
-                self.file.close()
-                raise ValueError(f"Error parsing line: {lnum} {file_path}: {e}")
-        self.mm.close()
-        self.file.close()
+            self.mm.close()
+            self.file.close()
+        except PermissionError:
+            if self.skip_files:
+                warnings.warn(f"Permission denied on {file_path}", UserWarning)
+            else:
+                raise PermissionError(f"Permission denied on {file_path}")
 
     @property
     def path(self) -> str:


### PR DESCRIPTION
Allow to skip unreadable files and directories, and raising a warning rather than an error. close #18 
- Added `--skip` flag on `cat`, `count` and `group by` command. 
- Be able to set `skip_files` on `Variant` and `find_files`.
- Added the corresponding functionality on `docs`.