### PR TITLE
fix: replace newline removal with rstrip for better line handling

### DIFF
--- a/openvariant/variant/variant.py
+++ b/openvariant/variant/variant.py
@@ -50,7 +50,7 @@ def _base_parser(mm_obj: mmap, file_path: str, delimiter: str, skip_files: bool)
         for l_num, line in enumerate(iter(mm_obj.readline, b'')):
             line = line.decode('utf-8')
             row_line = line.split(AnnotationDelimiter[delimiter].value)
-            row_line = list(map(lambda w: w.replace("\n", ""), row_line))
+            row_line = list(map(lambda w: w.rstrip("\r\n"), row_line))
 
             if len(row_line) == 0:
                 continue


### PR DESCRIPTION
This pull request includes an important change to the `_base_parser` function in the `openvariant/variant/variant.py` file to improve the handling of line endings in order to parse windows-based text correctly.

* [`openvariant/variant/variant.py`](diffhunk://#diff-8699efdd2c70a5e2f0546733756a252027e3bbe6be1ee6af656d5c07de4b2c90L53-R53): Modified the lambda function in the `_base_parser` method to use `rstrip("\r\n")` instead of `replace("\n", "")` for better handling of different line endings.

- related to #47

source [stackoverflow](https://stackoverflow.com/a/26280760)