### PR TITLE
feat: add Dockerfile for building and installing openvariant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ghcr.io/astral-sh/uv:0.5-python3.13-bookworm AS build-stage
+
+# Set environment variables
+ENV UV_COMPILE_BYTECODE=1
+
+# Set the working directory to /openvariant
+WORKDIR /openvariant
+
+# Stage necessary files into the container
+COPY uv.lock uv.lock
+COPY pyproject.toml pyproject.toml
+COPY openvariant openvariant
+COPY LICENSE LICENSE
+COPY README.md README.md
+
+# Install dependencies and build the project
+RUN mkdir -p /root/.cache/uv \
+    && uv sync --frozen --no-dev \
+    && uv build
+
+# Second stage: Runtime image
+FROM python:3.13-bookworm AS runtime-stage
+
+# Copy openvariant from the build stage
+COPY --from=build-stage /openvariant/dist /openvariant/dist
+WORKDIR /openvariant
+
+# Install openvariant
+RUN pip install dist/*.tar.gz 
+
+# Test the installation
+RUN openvar --help

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For more details check our [Installation](https://openvariant.readthedocs.io/en/
 
 ### Running with Docker
 
-You can quickly build and run OpenVariant using Docker without installing dependencies locally using [Dockerfile](./Dockerfile):
+You can quickly build and run OpenVariant using [Dockerfile](./Dockerfile) without installing dependencies locally:
 
 ```bash
 docker build -t openvariant .

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ pip install open-variant
 
 For more details check our [Installation](https://openvariant.readthedocs.io/en/latest/installation.html) section.
 
+### Running with Docker
+
+You can quickly build and run OpenVariant using Docker without installing dependencies locally using [Dockerfile](./Dockerfile):
+
+```bash
+docker build -t openvariant .
+docker run --rm openvariant openvar --help
+```
+
 ## Examples
 
 We provide a variety of [examples](https://github.com/bbglab/openvariant/tree/master/examples) to help to understand how OpenVariant can be applied. Explore the 


### PR DESCRIPTION
This pull request introduces a `Dockerfile` to build and run the `openvariant` project. The `Dockerfile` consists of two stages: a build stage and a runtime stage. The most important changes include setting up the build environment, copying necessary files, installing dependencies, and testing the installation.