### PR TITLE
fix: allow absolute mapping file paths

### DIFF
--- a/openvariant/annotation/builder.py
+++ b/openvariant/annotation/builder.py
@@ -213,9 +213,8 @@ class MAPPING:
         values: dict = {}
         mapping_files = x[AnnotationKeys.FILE_MAPPING.value]
         if mapping_files is None:
-            mapping_path = join(dirname(base_path), str(mapping_files))
-        else:
-            mapping_path = mapping_files if isabs(mapping_files) else join(dirname(base_path), mapping_files)
+            raise FileNotFoundError(f"'{AnnotationKeys.FILE_MAPPING.value}' must be provided for mapping annotations.")
+        mapping_path = mapping_files if isabs(mapping_files) else join(dirname(base_path), mapping_files)
         files = list(glob.iglob(mapping_path, recursive=True))
         if len(files) == 0:
             raise FileNotFoundError(f"Unable to find '{mapping_files}' file in '{dirname(base_path)}'")

--- a/openvariant/annotation/builder.py
+++ b/openvariant/annotation/builder.py
@@ -11,7 +11,7 @@ import glob
 import gzip
 import importlib
 import importlib.util
-from os.path import dirname
+from os.path import dirname, isabs, join
 from typing import Tuple, Any, List, Callable
 
 from openvariant.annotation.config_annotation import AnnotationKeys, AnnotationTypes
@@ -212,7 +212,11 @@ class MAPPING:
         """
         values: dict = {}
         mapping_files = x[AnnotationKeys.FILE_MAPPING.value]
-        files = list(glob.iglob(f"{dirname(base_path)}/{mapping_files}", recursive=True))
+        if mapping_files is None:
+            mapping_path = join(dirname(base_path), str(mapping_files))
+        else:
+            mapping_path = mapping_files if isabs(mapping_files) else join(dirname(base_path), mapping_files)
+        files = list(glob.iglob(mapping_path, recursive=True))
         if len(files) == 0:
             raise FileNotFoundError(f"Unable to find '{mapping_files}' file in '{dirname(base_path)}'")
         try:

--- a/tests/test_annotation/test_builder.py
+++ b/tests/test_annotation/test_builder.py
@@ -163,6 +163,22 @@ class TestBuilder(unittest.TestCase):
         self.assertEqual(field_sources, ['donor_id', 'id', 'Donor_Id'])
         self.assertEqual(mapping, expect_mapping)
 
+    def test_builder_mapping_with_absolute_file_mapping(self):
+        mapping_dict = {'type': 'mapping', 'field': 'CANCER_TYPE', 'fieldSource': ['donor_id', 'id', 'Donor_Id'],
+                        'fieldMapping': 'icgc_donor_id',
+                        'fileMapping': f'{os.getcwd()}/tests/data/builder/metadata.tsv',
+                        'fieldValue': 'cancer_type'}
+        annotation_path = f'{os.getcwd()}/tests/data/builder/metadata.yaml'
+
+        expect_mapping = {'DO48316': 'ESCA', 'DO48318': 'ESCA', 'DO48312': 'ESCA', 'DO50633': 'EWS'}
+
+        instance = MAPPING()
+        type_annot, field_sources, mapping = instance(mapping_dict, annotation_path)
+
+        self.assertEqual(type_annot, AnnotationTypes.MAPPING.name)
+        self.assertEqual(field_sources, ['donor_id', 'id', 'Donor_Id'])
+        self.assertEqual(mapping, expect_mapping)
+
     def test_builder_invalid_mapping(self):
         mapping_dict = {'type': 'mapping', 'field': 'CANCER_TYPE', 'fieldSource': None,
                         'fieldMapping': None, 'fileMapping': None, 'fieldValue': None}


### PR DESCRIPTION
Summary:
- resolve absolute `fileMapping` values directly instead of prefixing them with the annotation file directory
- keep relative `fileMapping` values resolved from the annotation file directory
- add a builder regression for an absolute mapping file path

Related issues:
- Closes #55

Validation:
- `rg -n "mapping_path|isabs|absolute_file_mapping|fileMapping" openvariant/annotation/builder.py tests/test_annotation/test_builder.py`
- `git diff --check`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`
- Not run locally: test suite
